### PR TITLE
(WIP) Adding fish support

### DIFF
--- a/src/opts.rs
+++ b/src/opts.rs
@@ -43,20 +43,27 @@ pub struct ShellOpts {
     /// Parse Bash history
     #[structopt(long="flavor-bash")]
     pub bash: bool,
+
+    /// Parse Fish history
+    #[structopt(long="flavor-fish")]
+    pub fish: bool,
 }
 
+#[derive(Copy, Clone)]
 pub enum HistoryFlavor {
     Zsh,
     Bash,
+    Fish
 }
 
 impl ShellOpts {
     pub fn validate(self) -> HistoryFlavor {
-        match (self.zsh, self.bash) {
-            (false, false) => HistoryFlavor::Zsh,
-            (true, false) => HistoryFlavor::Zsh,
-            (false, true) => HistoryFlavor::Bash,
-            (true, true) => {
+        match (self.zsh, self.bash, self.fish) {
+            (false, false, false) => HistoryFlavor::Zsh,
+            (true, false, false) => HistoryFlavor::Zsh,
+            (false, true, false) => HistoryFlavor::Bash,
+            (false, false, true) => HistoryFlavor::Fish,
+            (_, _, _) => {
                 eprintln!("Multiple shell modes selected, please select one or none");
                 std::process::exit(-1);
             }


### PR DESCRIPTION
This PR adds fish[1] support to shell-hist. Unfortunately it seems to
still be slightly buggy, as the generated statics don't really make
much sense - maybe you have an idea of what's going on here.

But generally: fish's `fish_history` is kinda annoying to parse since
they use an almost(tm)-yaml syntax. So instead I restructured the code
to act on a large string instead, then providing a function that
returns said string. In the case of `fish` we just shell out to
`history(1)` to read the `fish_history` for us :)