### PR TITLE
Support HISTFILE, clippy, cargo fmt

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,16 +35,16 @@ fn main() {
 
     let lines = ct_node_to_list_line(func(&t, opt.count, ""));
 
-    println!("");
+    println!();
     println!("  {} Commands ", title);
-    println!("");
+    println!();
     println!("|  HEAT    |  COUNT   |  COMMAND ");
     println!("| -------- | -------- | ---------");
 
-    for i in lines.iter() {
+    for i in &lines {
         println!("| {} | {:8} | {}", pct_to_bar(i.pct, BARS_WIDE), i.node.count, i.node.full_text);
     }
-    println!("");
+    println!();
 
 }
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -1,9 +1,9 @@
+use crate::eject;
+use dirs::home_dir;
+use regex::Regex;
 use std::env;
 use std::path::PathBuf;
 use structopt::StructOpt;
-use regex::Regex;
-use dirs::home_dir;
-use crate::eject;
 
 #[derive(StructOpt)]
 pub struct Options {
@@ -22,30 +22,29 @@ pub struct Options {
     pub count: usize,
 }
 
-
 #[derive(StructOpt)]
 pub struct DisplayOpts {
     /// Show fuzzy matched output. This is the default option.
-    #[structopt(short="z", long="display-fuzzy")]
+    #[structopt(short = "z", long = "display-fuzzy")]
     pub fuzzy: bool,
 
     /// Show the most common exact commands
-    #[structopt(short="e", long="display-exact")]
+    #[structopt(short = "e", long = "display-exact")]
     pub exact: bool,
 
     /// Show the most common command components
-    #[structopt(short="t", long="display-heat")]
+    #[structopt(short = "t", long = "display-heat")]
     pub heat: bool,
 }
 
 #[derive(StructOpt)]
 pub struct ShellOpts {
     /// Manually select ZSH history, overriding auto-detect
-    #[structopt(long="flavor-zsh")]
+    #[structopt(long = "flavor-zsh")]
     pub zsh: bool,
 
     /// Manually select Bash history, overriding auto-detect
-    #[structopt(long="flavor-bash")]
+    #[structopt(long = "flavor-bash")]
     pub bash: bool,
 }
 
@@ -57,10 +56,8 @@ pub enum HistoryFlavor {
 
 impl ShellOpts {
     pub fn detect_shell() -> Option<HistoryFlavor> {
-        const SHELL_MATCHES: &[(&str, HistoryFlavor)] = &[
-            ("zsh", HistoryFlavor::Zsh),
-            ("bash", HistoryFlavor::Bash),
-        ];
+        const SHELL_MATCHES: &[(&str, HistoryFlavor)] =
+            &[("zsh", HistoryFlavor::Zsh), ("bash", HistoryFlavor::Bash)];
 
         let shell_path = env::var("SHELL").ok()?;
 
@@ -81,7 +78,7 @@ impl ShellOpts {
                 } else {
                     eject("Unable to detect shell, please manually select a shell flavor");
                 }
-            },
+            }
             (true, false) => HistoryFlavor::Zsh,
             (false, true) => HistoryFlavor::Bash,
             (true, true) => {
@@ -114,17 +111,13 @@ impl HistoryFlavor {
     pub fn regex_and_capture_idx(&self) -> (Regex, usize) {
         use HistoryFlavor::*;
         let (re_res, idx) = match self {
-            Zsh => {
-                (Regex::new(r"^.*;(sudo )?(.*)$"), 2)
-            },
-            Bash => {
-                (Regex::new(r"^(sudo )?(.*)$"), 2)
-            }
+            Zsh => (Regex::new(r"^.*;(sudo )?(.*)$"), 2),
+            Bash => (Regex::new(r"^(sudo )?(.*)$"), 2),
         };
 
         (
             re_res.unwrap_or_else(|_| eject("Failed to compile regex!")),
-            idx
+            idx,
         )
     }
 }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -137,8 +137,7 @@ pub enum DisplayMode {
 impl DisplayOpts {
     pub fn validate(self) -> DisplayMode {
         match (self.fuzzy, self.exact, self.heat) {
-            (false, false, false) => DisplayMode::Fuzzy,
-            (true, false, false) => DisplayMode::Fuzzy,
+            (_, false, false) => DisplayMode::Fuzzy,
             (false, true, false) => DisplayMode::Exact,
             (false, false, true) => DisplayMode::Heat,
             _ => {

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -94,20 +94,21 @@ impl ShellOpts {
 impl HistoryFlavor {
     pub fn history_path(&self) -> PathBuf {
         use HistoryFlavor::*;
-        let name = match self {
-            Zsh => {
-                ".zsh_history"
-            },
-            Bash => {
-                ".bash_history"
-            }
-        };
 
-        let mut dir = home_dir().unwrap_or_else(|| {
-            eject("Unable to determine home path. Please specify history file path");
-        });
-        dir.push(name);
-        dir
+        if let Ok(hist_file) = std::env::var("HISTFILE") {
+            PathBuf::from(hist_file)
+        } else {
+            let name = match self {
+                Zsh => ".zsh_history",
+                Bash => ".bash_history",
+            };
+
+            let mut dir = home_dir().unwrap_or_else(|| {
+                eject("Unable to determine home path. Please specify history file path");
+            });
+            dir.push(name);
+            dir
+        }
     }
 
     pub fn regex_and_capture_idx(&self) -> (Regex, usize) {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -164,7 +164,7 @@ impl Node {
     }
 }
 
-pub fn parse<'a>(path: Option<PathBuf>, flavor: HistoryFlavor) -> Node  {
+pub fn parse(path: Option<PathBuf>, flavor: HistoryFlavor) -> Node  {
     let mut tree = Node::new();
 
     let path = path.unwrap_or_else(|| {


### PR DESCRIPTION
Some people like me don't use `~/.zsh_history` for our shell history.